### PR TITLE
feat: implement Open Graph image generation and improve blog cursor p…

### DIFF
--- a/src/app/[locale]/[...slug]/page.tsx
+++ b/src/app/[locale]/[...slug]/page.tsx
@@ -21,7 +21,17 @@ export async function generateMetadata({ params }: PageProps<"/[locale]/[...slug
     getSiteShellData(locale)
   ]);
   if (!page) return {};
-  return createPageMetadata({ locale, path: `/${path}`, site: siteMetadata, title: page.title });
+  const localizedPaths = Object.fromEntries([
+    [page.locale, `/${page.slug}`],
+    ...page.translations.map((translation) => [translation.locale, `/${translation.slug}`])
+  ]);
+  return createPageMetadata({
+    locale,
+    path: `/${path}`,
+    site: siteMetadata,
+    title: page.title,
+    localizedPaths
+  });
 }
 
 export default async function CustomPage({ params }: PageProps<"/[locale]/[...slug]">) {

--- a/src/app/[locale]/album/[slug]/page.tsx
+++ b/src/app/[locale]/album/[slug]/page.tsx
@@ -28,7 +28,8 @@ export async function generateMetadata({ params }: PageProps<"/[locale]/album/[s
     locale,
     path: `/album/${slug}`,
     site: siteMetadata,
-    title: album.name
+    title: album.name,
+    ogImage: { type: "album", id: album.id }
   });
 }
 

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -28,7 +28,14 @@ export async function generateMetadata({ params }: PageProps<"/[locale]/blog/[sl
     locale,
     path: `/blog/${slug}`,
     site: siteMetadata,
-    title: data.current.title
+    title: data.current.title,
+    localizedPaths: Object.fromEntries(
+      Object.entries(data.current.localizedSlugs).map(([candidateLocale, candidateSlug]) => [
+        candidateLocale,
+        `/blog/${candidateSlug}`
+      ])
+    ),
+    ogImage: { type: "post", id: data.current.id }
   });
 }
 

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -21,6 +21,7 @@ export default async function BlogPage({ params }: PageProps<"/[locale]/blog">) 
     <div className="flex flex-col justify-center">
       <Breadcrumbs items={[{ name: "blog", url: "/blog" }]} />
       <BlogIndex
+        initialCursor={data.nextCursor}
         initialPosts={data.posts ?? []}
         locale={locale}
         totalCount={data.totalCount ?? 0}

--- a/src/app/api/blog/posts/route.test.ts
+++ b/src/app/api/blog/posts/route.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { encodeBlogCursor } from "@/lib/pagination";
+
+const { getNextCursor, getPostsAfter } = vi.hoisted(() => ({
+  getNextCursor: vi.fn(),
+  getPostsAfter: vi.fn()
+}));
+
+vi.mock("@/sanity/repositories/blogRepository", () => ({ getNextCursor, getPostsAfter }));
+
+import { GET } from "./route";
+
+describe("GET /api/blog/posts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("decodes an opaque cursor before querying and returns a server-generated cursor", async () => {
+    const cursor = { id: "post-2", publishDate: "2026-07-16T12:00:00.000Z" };
+    const items = [{ id: "post-1", publishDate: "2026-07-15T12:00:00.000Z" }];
+    getPostsAfter.mockResolvedValue(items);
+    getNextCursor.mockReturnValue("next-opaque-cursor");
+
+    const response = await GET(
+      new Request(
+        `https://fpbrault.com/api/blog/posts?locale=en&limit=3&cursor=${encodeBlogCursor(cursor)}`
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(getPostsAfter).toHaveBeenCalledWith("en", cursor, 3);
+    expect(getNextCursor).toHaveBeenCalledWith(items);
+    await expect(response.json()).resolves.toEqual({
+      items,
+      nextCursor: "next-opaque-cursor"
+    });
+  });
+
+  it("rejects a malformed cursor without querying Sanity", async () => {
+    const response = await GET(
+      new Request("https://fpbrault.com/api/blog/posts?locale=en&limit=3&cursor=not-a-cursor")
+    );
+
+    expect(response.status).toBe(400);
+    expect(getPostsAfter).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -1,4 +1,4 @@
-import { getPostsAfter } from "@/sanity/repositories/blogRepository";
+import { getNextCursor, getPostsAfter } from "@/sanity/repositories/blogRepository";
 import { blogCursorQuerySchema } from "@/lib/pagination";
 
 export async function GET(request: Request) {
@@ -8,7 +8,7 @@ export async function GET(request: Request) {
 
   const items = await getPostsAfter(parsed.data.locale, parsed.data.cursor, parsed.data.limit);
   return Response.json(
-    { items, nextCursor: items.at(-1)?.publishDate ?? null },
+    { items, nextCursor: getNextCursor(items) },
     { headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300" } }
   );
 }

--- a/src/app/api/og/route.test.ts
+++ b/src/app/api/og/route.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetch } = vi.hoisted(() => ({ fetch: vi.fn() }));
+
+vi.mock("next/og", () => ({
+  ImageResponse: class extends Response {
+    constructor(_element: unknown, init: ResponseInit) {
+      super("image", init);
+    }
+  }
+}));
+vi.mock("@/sanity/lib/client", () => ({ getSanityClient: () => ({ fetch }) }));
+vi.mock("@/sanity/lib/image", () => ({
+  urlForImage: () => ({
+    width: () => ({
+      height: () => ({ fit: () => ({ url: () => "https://cdn.example/image.jpg" }) })
+    })
+  })
+}));
+
+import { OG_ALBUM_IMAGE_QUERY, OG_POST_IMAGE_QUERY } from "@/sanity/queries";
+import { GET } from "./route";
+
+describe("GET /api/og", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("looks up a post cover by stable document ID", async () => {
+    fetch.mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("https://fpbrault.com/api/og?title=Post&postId=post-123")
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(OG_POST_IMAGE_QUERY, { id: "post-123" });
+  });
+
+  it("looks up an album cover by stable document ID", async () => {
+    fetch.mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("https://fpbrault.com/api/og?title=Album&albumId=album-123")
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(OG_ALBUM_IMAGE_QUERY, { id: "album-123" });
+  });
+
+  it("falls back to the generic image when Sanity fails", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    fetch.mockRejectedValue(new Error("Sanity unavailable"));
+
+    const response = await GET(
+      new Request("https://fpbrault.com/api/og?title=Post&postId=post-123")
+    );
+
+    expect(response.status).toBe(200);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('"event":"og_query_error"'));
+    error.mockRestore();
+  });
+
+  it("rejects oversized identifiers", async () => {
+    const response = await GET(
+      new Request(`https://fpbrault.com/api/og?postId=${"x".repeat(121)}`)
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -10,7 +10,7 @@ export const runtime = "nodejs";
 
 const querySchema = z.object({
   albumId: z.string().max(120).optional(),
-  slug: z.string().max(120).optional(),
+  postId: z.string().max(120).optional(),
   title: z.string().max(120).default("Felix Perron-Brault Photographe")
 });
 
@@ -18,12 +18,12 @@ export async function GET(request: Request) {
   const parsed = querySchema.safeParse(Object.fromEntries(new URL(request.url).searchParams));
   if (!parsed.success) return new Response("Invalid query", { status: 400 });
 
-  const { albumId, slug, title } = parsed.data;
+  const { albumId, postId, title } = parsed.data;
   let image: { asset?: { _ref: string; _type: "reference" } } | null = null;
   try {
-    if (slug) image = await getSanityClient().fetch(OG_POST_IMAGE_QUERY, { slug });
+    if (postId) image = await getSanityClient().fetch(OG_POST_IMAGE_QUERY, { id: postId });
     if (!image && albumId)
-      image = await getSanityClient().fetch(OG_ALBUM_IMAGE_QUERY, { slug: albumId });
+      image = await getSanityClient().fetch(OG_ALBUM_IMAGE_QUERY, { id: albumId });
   } catch (error) {
     console.error(
       JSON.stringify({

--- a/src/components/Albums/NextJsImage.test.tsx
+++ b/src/components/Albums/NextJsImage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import type { RenderPhotoProps } from "react-photo-album";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt = "",
+    blurDataURL,
+    placeholder,
+    ...props
+  }: ComponentProps<"img"> & { blurDataURL?: string; placeholder?: string }) => {
+    void blurDataURL;
+    return (
+      // eslint-disable-next-line @next/next/no-img-element -- test double exposes Next Image props.
+      <img {...props} alt={alt} data-placeholder={placeholder} />
+    );
+  }
+}));
+
+import { NextJsImageElement, type GalleryPhoto } from "./NextJsImage";
+
+function renderPhoto(lqip?: string) {
+  const photo: GalleryPhoto = {
+    _key: "photo-1",
+    _type: "image",
+    alt: "Winter landscape",
+    asset: {
+      _ref: "image-4338b28bcb30c42a571234d34c1d4507b2704b98-3088x2048-jpg",
+      _type: "reference"
+    },
+    decorative: false,
+    description: undefined,
+    featured: false,
+    height: 2048,
+    placeholders: { metadata: { lqip } },
+    src: "https://cdn.sanity.io/image.jpg",
+    title: "Winter",
+    width: 3088
+  };
+
+  const props = {
+    photo,
+    imageProps: { alt: photo.alt, sizes: "100vw", src: photo.src, style: {} },
+    wrapperStyle: {}
+  } as RenderPhotoProps<GalleryPhoto>;
+
+  render(<NextJsImageElement {...props} />);
+}
+
+describe("gallery Next Image placeholder", () => {
+  it("uses an empty placeholder when Sanity has no LQIP", () => {
+    renderPhoto();
+    expect(screen.getByRole("img")).toHaveAttribute("data-placeholder", "empty");
+  });
+
+  it("uses the Sanity LQIP when it exists", () => {
+    renderPhoto("data:image/jpeg;base64,blurred");
+    expect(screen.getByRole("img")).toHaveAttribute("data-placeholder", "blur");
+  });
+});

--- a/src/components/Albums/NextJsImage.tsx
+++ b/src/components/Albums/NextJsImage.tsx
@@ -48,7 +48,7 @@ export function NextJsImageAlbum({
           src={photo.src}
           loading="lazy"
           blurDataURL={photo.blurDataURL}
-          placeholder={"blur"}
+          placeholder={photo.blurDataURL ? "blur" : "empty"}
           sizes={sizes}
           {...{ alt, title, onClick }}
         />
@@ -77,8 +77,8 @@ export function NextJsImageElement({
         className="object-contain rounded"
         src={thumbnailUrl}
         loading="lazy"
-        blurDataURL={photo?.placeholders?.metadata.lqip}
-        placeholder={"blur"}
+        blurDataURL={photo.placeholders.metadata.lqip}
+        placeholder={photo.placeholders.metadata.lqip ? "blur" : "empty"}
         sizes={sizes}
         {...{ alt, onClick }}
       />
@@ -128,9 +128,9 @@ export function NextJsImage({ slide, rect }: NextJsImageProps) {
         title={slide.alt}
         src={slide.src}
         loading="lazy"
-        blurDataURL={slide?.placeholders?.metadata.lqip}
+        blurDataURL={slide.placeholders?.metadata.lqip}
         draggable={false}
-        placeholder={"blur"}
+        placeholder={slide.placeholders?.metadata.lqip ? "blur" : "empty"}
         style={{ objectFit: cover ? "cover" : "contain" }}
         sizes={`${Math.ceil((width / window.innerWidth) * 100)}vw`}
       />

--- a/src/components/Blog/Post.tsx
+++ b/src/components/Blog/Post.tsx
@@ -15,8 +15,8 @@ export default function Post({ post }: { post: PostData }) {
           {image ? (
             <Image
               className="mx-auto rounded shadow-2xl max-h-[750px] object-contain max-w-fit"
-              blurDataURL={post?.blurDataURL ?? ""}
-              placeholder="blur"
+              blurDataURL={post.blurDataURL}
+              placeholder={post.blurDataURL ? "blur" : "empty"}
               height={image?.imageHeight ?? ""}
               width={image?.imageWidth ?? ""}
               alt={post.title}

--- a/src/features/blog/BlogIndex.tsx
+++ b/src/features/blog/BlogIndex.tsx
@@ -8,17 +8,19 @@ import type { Locale } from "@/i18n/config";
 
 export function BlogIndex({
   initialPosts,
+  initialCursor,
   locale,
   totalCount
 }: {
   initialPosts: PostSummary[];
+  initialCursor: string | null;
   locale: Locale;
   totalCount: number;
 }) {
   const [posts, setPosts] = useState(initialPosts);
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string>();
-  const [nextCursor, setNextCursor] = useState(initialPosts.at(-1)?.publishDate ?? null);
+  const [nextCursor, setNextCursor] = useState(initialCursor);
   const requestRef = useRef<AbortController | null>(null);
 
   useEffect(() => () => requestRef.current?.abort(), []);

--- a/src/features/blog/blogMapper.ts
+++ b/src/features/blog/blogMapper.ts
@@ -45,9 +45,14 @@ export function mapPostPage(input: POST_QUERY_RESULT): PostPage | null {
 
   const current: Post = {
     id: input.current._id,
+    blurDataURL: input.current.blurDataURL ?? undefined,
     coverImage: mapContentImage(input.current.coverImage, `${input.current._id}-cover`),
     content: input.current.content ?? [],
     excerpt: "",
+    localizedSlugs: {
+      ...(input.current.slugs.en ? { en: input.current.slugs.en } : {}),
+      ...(input.current.slugs.fr ? { fr: input.current.slugs.fr } : {})
+    },
     publishDate: input.current.publishDate,
     slug,
     title: input.current.title ?? "Untitled post"

--- a/src/features/blog/models.ts
+++ b/src/features/blog/models.ts
@@ -1,4 +1,5 @@
 import type { ContentImage, PortableContent } from "@/features/content/models";
+import type { Locale } from "@/i18n/config";
 
 export type PostSummary = {
   id: string;
@@ -12,6 +13,7 @@ export type PostSummary = {
 
 export type Post = PostSummary & {
   content: PortableContent;
+  localizedSlugs: Partial<Record<Locale, string>>;
 };
 
 export type PostPage = {

--- a/src/lib/metadata.test.ts
+++ b/src/lib/metadata.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { createPageMetadata } from "./metadata";
+
+const site = {
+  author: "Felix",
+  description: "Photography",
+  siteTitle: "FPB",
+  socialLinks: []
+};
+
+describe("page metadata", () => {
+  it("uses actual localized paths while preserving the unprefixed English URL", () => {
+    const metadata = createPageMetadata({
+      locale: "fr",
+      localizedPaths: { en: "/blog/english-slug", fr: "/blog/limace-francaise" },
+      path: "/blog/limace-francaise",
+      site,
+      title: "Article"
+    });
+
+    expect(metadata.alternates?.canonical?.toString()).toBe(
+      "https://fpbrault.com/fr/blog/limace-francaise"
+    );
+    expect(metadata.alternates?.languages).toEqual({
+      en: new URL("https://fpbrault.com/blog/english-slug"),
+      fr: new URL("https://fpbrault.com/fr/blog/limace-francaise")
+    });
+  });
+
+  it("omits a missing translation instead of advertising a nonexistent URL", () => {
+    const metadata = createPageMetadata({
+      locale: "en",
+      localizedPaths: { en: "/about" },
+      path: "/about",
+      site,
+      title: "About"
+    });
+
+    expect(metadata.alternates?.languages).toEqual({
+      en: new URL("https://fpbrault.com/about")
+    });
+  });
+
+  it("adds a stable content ID to an album OG image URL", () => {
+    const metadata = createPageMetadata({
+      locale: "en",
+      ogImage: { type: "album", id: "album-123" },
+      path: "/album/winter",
+      site,
+      title: "Winter"
+    });
+
+    expect(metadata.openGraph?.images).toEqual([
+      { url: new URL("https://fpbrault.com/api/og?title=Winter&albumId=album-123") }
+    ]);
+    expect(metadata.twitter?.images).toEqual([
+      new URL("https://fpbrault.com/api/og?title=Winter&albumId=album-123")
+    ]);
+  });
+});

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -14,27 +14,42 @@ export function createPageMetadata({
   path,
   site,
   title,
-  description = site.description
+  description = site.description,
+  localizedPaths,
+  ogImage
 }: {
   locale: Locale;
   path: string;
   site: SiteMetadata;
   title: string;
   description?: string;
+  localizedPaths?: Partial<Record<Locale, string>>;
+  ogImage?: { type: "album" | "post"; id: string };
 }): Metadata {
-  const localizedPath = localizePath(path, locale);
+  const localizedPath = localizePath(localizedPaths?.[locale] ?? path, locale);
   const canonical = new URL(localizedPath, getSiteUrl());
   const fullTitle = title === site.siteTitle ? title : `${site.siteTitle} - ${title}`;
+  const imageUrl = new URL("/api/og", getSiteUrl());
+  imageUrl.searchParams.set("title", title);
+  if (ogImage) imageUrl.searchParams.set(`${ogImage.type}Id`, ogImage.id);
+
+  const languages = Object.fromEntries(
+    (["en", "fr"] as const).flatMap((candidateLocale) => {
+      const candidatePath = localizedPaths
+        ? localizedPaths[candidateLocale]
+        : localizePath(path, candidateLocale);
+      return candidatePath
+        ? [[candidateLocale, new URL(localizePath(candidatePath, candidateLocale), getSiteUrl())]]
+        : [];
+    })
+  );
 
   return {
     title: fullTitle,
     description,
     alternates: {
       canonical,
-      languages: {
-        en: new URL(localizePath(path, "en"), getSiteUrl()),
-        fr: new URL(localizePath(path, "fr"), getSiteUrl())
-      }
+      languages
     },
     openGraph: {
       type: "website",
@@ -42,13 +57,13 @@ export function createPageMetadata({
       url: canonical,
       title: fullTitle,
       description,
-      images: [{ url: new URL(`/api/og?title=${encodeURIComponent(title)}`, getSiteUrl()) }]
+      images: [{ url: imageUrl }]
     },
     twitter: {
       card: "summary_large_image",
       title: fullTitle,
       description,
-      images: [new URL(`/api/og?title=${encodeURIComponent(title)}`, getSiteUrl())]
+      images: [imageUrl]
     }
   };
 }

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -1,21 +1,33 @@
 import { describe, expect, it } from "vitest";
 
-import { blogCursorQuerySchema } from "./pagination";
+import { blogCursorQuerySchema, decodeBlogCursor, encodeBlogCursor } from "./pagination";
 
 describe("blog cursor input", () => {
+  const cursor = {
+    id: "post-123",
+    publishDate: "2026-07-16T12:00:00.000Z"
+  };
+
+  it("round-trips an opaque publish date and document ID cursor", () => {
+    const encoded = encodeBlogCursor(cursor);
+
+    expect(encoded).not.toContain(cursor.publishDate);
+    expect(decodeBlogCursor(encoded)).toEqual(cursor);
+  });
+
   it("accepts a bounded request", () => {
     const result = blogCursorQuerySchema.parse({
-      cursor: "2026-07-16T12:00:00.000Z",
+      cursor: encodeBlogCursor(cursor),
       limit: "12",
       locale: "fr"
     });
-    expect(result).toEqual({ cursor: "2026-07-16T12:00:00.000Z", limit: 12, locale: "fr" });
+    expect(result).toEqual({ cursor, limit: 12, locale: "fr" });
   });
 
   it.each([
     { cursor: "bad", limit: "3", locale: "en" },
-    { cursor: "2026-07-16T12:00:00.000Z", limit: "13", locale: "en" },
-    { cursor: "2026-07-16T12:00:00.000Z", limit: "3", locale: "es" }
+    { cursor: encodeBlogCursor(cursor), limit: "13", locale: "en" },
+    { cursor: encodeBlogCursor(cursor), limit: "3", locale: "es" }
   ])("rejects invalid query %#", (query) => {
     expect(blogCursorQuerySchema.safeParse(query).success).toBe(false);
   });

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,7 +1,31 @@
 import { z } from "zod";
 
+const blogCursorSchema = z.object({
+  id: z.string().min(1),
+  publishDate: z.iso.datetime()
+});
+
+export type BlogCursor = z.infer<typeof blogCursorSchema>;
+
+export function encodeBlogCursor(cursor: BlogCursor): string {
+  return Buffer.from(JSON.stringify(blogCursorSchema.parse(cursor))).toString("base64url");
+}
+
+export function decodeBlogCursor(value: string): BlogCursor | null {
+  try {
+    return blogCursorSchema.parse(JSON.parse(Buffer.from(value, "base64url").toString("utf8")));
+  } catch {
+    return null;
+  }
+}
+
 export const blogCursorQuerySchema = z.object({
-  cursor: z.iso.datetime(),
+  cursor: z.string().transform((value, context) => {
+    const cursor = decodeBlogCursor(value);
+    if (cursor) return cursor;
+    context.addIssue({ code: "custom", message: "Invalid cursor" });
+    return z.NEVER;
+  }),
   limit: z.coerce.number().int().min(1).max(12).default(3),
   locale: z.enum(["en", "fr"])
 });

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -103,19 +103,19 @@ const postSummaryProjection = `{
 
 export const POST_LIST_QUERY = defineQuery(`{
   "posts": *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]
-    | order(publishDate desc) [0...$limit] ${postSummaryProjection},
+    | order(publishDate desc, _id desc) [0...$limit] ${postSummaryProjection},
   "totalCount": count(*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))])
 }`);
 
 export const POST_CURSOR_QUERY = defineQuery(`
 *[_type == "post" && (defined(slug.current) || defined(slug_fr.current)) &&
-  (!defined($cursor) || publishDate < $cursor)]
-  | order(publishDate desc) [0...$limit] ${postSummaryProjection}
+  (publishDate < $cursorDate || (publishDate == $cursorDate && _id < $cursorId))]
+  | order(publishDate desc, _id desc) [0...$limit] ${postSummaryProjection}
 `);
 
 export const LATEST_POST_QUERY = defineQuery(`
 *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]
-  | order(publishDate desc) [0] ${postSummaryProjection}
+  | order(publishDate desc, _id desc) [0] ${postSummaryProjection}
 `);
 
 export const POST_QUERY = defineQuery(`
@@ -124,6 +124,8 @@ export const POST_QUERY = defineQuery(`
     _id,
     publishDate,
     coverImage,
+    "blurDataURL": coverImage.asset->metadata.lqip,
+    "slugs": {"en": slug.current, "fr": slug_fr.current},
     "slug": select($locale == "fr" => coalesce(slug_fr, slug), coalesce(slug, slug_fr)),
     "title": title[_key == $locale][0].value,
     "content": postContent[_key == $locale][0].value
@@ -157,9 +159,9 @@ export const PAGE_SLUGS_QUERY = defineQuery(`
 `);
 
 export const OG_POST_IMAGE_QUERY = defineQuery(`
-*[_type == "post" && (slug.current == $slug || slug_fr.current == $slug)][0].coverImage
+*[_type == "post" && _id == $id][0].coverImage
 `);
 
 export const OG_ALBUM_IMAGE_QUERY = defineQuery(`
-*[_type == "album" && slug.current == $slug][0].images[0]
+*[_type == "album" && _id == $id][0].images[0]
 `);

--- a/src/sanity/repositories/blogRepository.ts
+++ b/src/sanity/repositories/blogRepository.ts
@@ -7,6 +7,7 @@ import {
   mapPostSummaries
 } from "@/features/blog/blogMapper";
 import type { Locale } from "@/i18n/config";
+import { encodeBlogCursor } from "@/lib/pagination";
 import { getSanityClient } from "@/sanity/lib/client";
 import { sanityFetch } from "@/sanity/lib/live";
 import {
@@ -25,19 +26,31 @@ export async function getPosts(locale: Locale, limit = 3) {
       params: { locale, limit },
       tags: ["posts"]
     });
-    return mapPostList(data);
+    const result = mapPostList(data);
+    return { ...result, nextCursor: getNextCursor(result.posts) };
   });
 }
 
-export async function getPostsAfter(locale: Locale, cursor: string | null, limit: number) {
+export async function getPostsAfter(
+  locale: Locale,
+  cursor: { id: string; publishDate: string },
+  limit: number
+) {
   return runSanityRequest("post-cursor", async () => {
     const { data } = await sanityFetch({
       query: POST_CURSOR_QUERY,
-      params: { locale, cursor, limit },
+      params: { locale, cursorDate: cursor.publishDate, cursorId: cursor.id, limit },
       tags: ["posts"]
     });
     return mapPostSummaries(data);
   });
+}
+
+export function getNextCursor(posts: Array<{ id: string; publishDate: string | null }>) {
+  const lastPost = posts.at(-1);
+  return lastPost?.publishDate
+    ? encodeBlogCursor({ id: lastPost.id, publishDate: lastPost.publishDate })
+    : null;
 }
 
 export async function getLatestPost(locale: Locale) {

--- a/src/sanity/sanity.types.ts
+++ b/src/sanity/sanity.types.ts
@@ -992,7 +992,7 @@ export type FEATURED_IMAGES_QUERY_RESULT = Array<{
 
 // Source: src/sanity/queries.ts
 // Variable: POST_LIST_QUERY
-// Query: {  "posts": *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]    | order(publishDate desc) [0...$limit] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."},  "totalCount": count(*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))])}
+// Query: {  "posts": *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]    | order(publishDate desc, _id desc) [0...$limit] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."},  "totalCount": count(*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))])}
 export type POST_LIST_QUERY_RESULT = {
   posts: Array<{
     _id: string;
@@ -1015,7 +1015,7 @@ export type POST_LIST_QUERY_RESULT = {
 
 // Source: src/sanity/queries.ts
 // Variable: POST_CURSOR_QUERY
-// Query: *[_type == "post" && (defined(slug.current) || defined(slug_fr.current)) &&  (!defined($cursor) || publishDate < $cursor)]  | order(publishDate desc) [0...$limit] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."}
+// Query: *[_type == "post" && (defined(slug.current) || defined(slug_fr.current)) &&  (publishDate < $cursorDate || (publishDate == $cursorDate && _id < $cursorId))]  | order(publishDate desc, _id desc) [0...$limit] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."}
 export type POST_CURSOR_QUERY_RESULT = Array<{
   _id: string;
   publishDate: string | null;
@@ -1035,7 +1035,7 @@ export type POST_CURSOR_QUERY_RESULT = Array<{
 
 // Source: src/sanity/queries.ts
 // Variable: LATEST_POST_QUERY
-// Query: *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]  | order(publishDate desc) [0] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."}
+// Query: *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]  | order(publishDate desc, _id desc) [0] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."}
 export type LATEST_POST_QUERY_RESULT = {
   _id: string;
   publishDate: string | null;
@@ -1055,7 +1055,7 @@ export type LATEST_POST_QUERY_RESULT = {
 
 // Source: src/sanity/queries.ts
 // Variable: POST_QUERY
-// Query: *[_type == "post" && (slug.current == $slug || slug_fr.current == $slug)][0]{  "current": {    _id,    publishDate,    coverImage,    "slug": select($locale == "fr" => coalesce(slug_fr, slug), coalesce(slug, slug_fr)),    "title": title[_key == $locale][0].value,    "content": postContent[_key == $locale][0].value  },  "previous": *[_type == "post" && publishDate < ^.publishDate] | order(publishDate desc)[0] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."},  "next": *[_type == "post" && publishDate > ^.publishDate] | order(publishDate asc)[0] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."}}
+// Query: *[_type == "post" && (slug.current == $slug || slug_fr.current == $slug)][0]{  "current": {    _id,    publishDate,    coverImage,    "blurDataURL": coverImage.asset->metadata.lqip,    "slugs": {"en": slug.current, "fr": slug_fr.current},    "slug": select($locale == "fr" => coalesce(slug_fr, slug), coalesce(slug, slug_fr)),    "title": title[_key == $locale][0].value,    "content": postContent[_key == $locale][0].value  },  "previous": *[_type == "post" && publishDate < ^.publishDate] | order(publishDate desc)[0] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."},  "next": *[_type == "post" && publishDate > ^.publishDate] | order(publishDate asc)[0] {  _id,  publishDate,  coverImage,  "slug": select(    $locale == "fr" => coalesce(slug_fr, slug),    coalesce(slug, slug_fr)  ),  "title": title[_key == $locale][0].value,  "blurDataURL": coverImage.asset->metadata.lqip,  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."}}
 export type POST_QUERY_RESULT = {
   current: {
     _id: string;
@@ -1068,6 +1068,11 @@ export type POST_QUERY_RESULT = {
       alt?: string;
       _type: "image";
     } | null;
+    blurDataURL: string | null;
+    slugs: {
+      en: string | null;
+      fr: string | null;
+    };
     slug: Slug | null;
     title: string | null;
     content: BlockContent | null;
@@ -1140,7 +1145,7 @@ export type PAGE_SLUGS_QUERY_RESULT = Array<{
 
 // Source: src/sanity/queries.ts
 // Variable: OG_POST_IMAGE_QUERY
-// Query: *[_type == "post" && (slug.current == $slug || slug_fr.current == $slug)][0].coverImage
+// Query: *[_type == "post" && _id == $id][0].coverImage
 export type OG_POST_IMAGE_QUERY_RESULT = {
   asset?: SanityImageAssetReference;
   media?: unknown;
@@ -1152,7 +1157,7 @@ export type OG_POST_IMAGE_QUERY_RESULT = {
 
 // Source: src/sanity/queries.ts
 // Variable: OG_ALBUM_IMAGE_QUERY
-// Query: *[_type == "album" && slug.current == $slug][0].images[0]
+// Query: *[_type == "album" && _id == $id][0].images[0]
 export type OG_ALBUM_IMAGE_QUERY_RESULT = {
   asset?: SanityImageAssetReference;
   media?: unknown;
@@ -1207,14 +1212,14 @@ declare module "@sanity/client" {
     '\n*[_type == "album" && defined(slug.current)]{"slug": slug.current}\n': ALBUM_SLUGS_QUERY_RESULT;
     '\n*[_type == "album"].images[]{\n  _key,\n  _type,\n  alt,\n  asset,\n  description,\n  decorative,\n  featured,\n  title,\n  "placeholders": {"metadata": {"lqip": asset->metadata.lqip}}\n}\n': ALL_IMAGES_QUERY_RESULT;
     '\n*[_type == "album"].images[featured == true]{\n  _key,\n  _type,\n  alt,\n  asset,\n  description,\n  decorative,\n  featured,\n  title,\n  "placeholders": {"metadata": {"lqip": asset->metadata.lqip}}\n}\n': FEATURED_IMAGES_QUERY_RESULT;
-    '{\n  "posts": *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]\n    | order(publishDate desc) [0...$limit] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n},\n  "totalCount": count(*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))])\n}': POST_LIST_QUERY_RESULT;
-    '\n*[_type == "post" && (defined(slug.current) || defined(slug_fr.current)) &&\n  (!defined($cursor) || publishDate < $cursor)]\n  | order(publishDate desc) [0...$limit] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n}\n': POST_CURSOR_QUERY_RESULT;
-    '\n*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]\n  | order(publishDate desc) [0] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n}\n': LATEST_POST_QUERY_RESULT;
-    '\n*[_type == "post" && (slug.current == $slug || slug_fr.current == $slug)][0]{\n  "current": {\n    _id,\n    publishDate,\n    coverImage,\n    "slug": select($locale == "fr" => coalesce(slug_fr, slug), coalesce(slug, slug_fr)),\n    "title": title[_key == $locale][0].value,\n    "content": postContent[_key == $locale][0].value\n  },\n  "previous": *[_type == "post" && publishDate < ^.publishDate] | order(publishDate desc)[0] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n},\n  "next": *[_type == "post" && publishDate > ^.publishDate] | order(publishDate asc)[0] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n}\n}': POST_QUERY_RESULT;
+    '{\n  "posts": *[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]\n    | order(publishDate desc, _id desc) [0...$limit] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n},\n  "totalCount": count(*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))])\n}': POST_LIST_QUERY_RESULT;
+    '\n*[_type == "post" && (defined(slug.current) || defined(slug_fr.current)) &&\n  (publishDate < $cursorDate || (publishDate == $cursorDate && _id < $cursorId))]\n  | order(publishDate desc, _id desc) [0...$limit] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n}\n': POST_CURSOR_QUERY_RESULT;
+    '\n*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]\n  | order(publishDate desc, _id desc) [0] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n}\n': LATEST_POST_QUERY_RESULT;
+    '\n*[_type == "post" && (slug.current == $slug || slug_fr.current == $slug)][0]{\n  "current": {\n    _id,\n    publishDate,\n    coverImage,\n    "blurDataURL": coverImage.asset->metadata.lqip,\n    "slugs": {"en": slug.current, "fr": slug_fr.current},\n    "slug": select($locale == "fr" => coalesce(slug_fr, slug), coalesce(slug, slug_fr)),\n    "title": title[_key == $locale][0].value,\n    "content": postContent[_key == $locale][0].value\n  },\n  "previous": *[_type == "post" && publishDate < ^.publishDate] | order(publishDate desc)[0] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n},\n  "next": *[_type == "post" && publishDate > ^.publishDate] | order(publishDate asc)[0] {\n  _id,\n  publishDate,\n  coverImage,\n  "slug": select(\n    $locale == "fr" => coalesce(slug_fr, slug),\n    coalesce(slug, slug_fr)\n  ),\n  "title": title[_key == $locale][0].value,\n  "blurDataURL": coverImage.asset->metadata.lqip,\n  "excerpt": array::join(string::split(pt::text(postContent[_key == $locale][0].value), "")[0...255], "") + "..."\n}\n}': POST_QUERY_RESULT;
     '\n*[_type == "post" && (defined(slug.current) || defined(slug_fr.current))]{\n  "slug": slug.current,\n  "slugFr": slug_fr.current\n}': POST_SLUGS_QUERY_RESULT;
     '\n*[_type == "page" && slug.current == $slug && language == $locale][0]{\n  _id,\n  title,\n  slug,\n  language,\n  content,\n  "_translations": *[_type == "translation.metadata" && references(^._id)].translations[].value->{\n    language,\n    title,\n    slug\n  }\n}': PAGE_QUERY_RESULT;
     '\n*[_type == "page" && defined(slug.current)]{language, "slug": slug.current}\n': PAGE_SLUGS_QUERY_RESULT;
-    '\n*[_type == "post" && (slug.current == $slug || slug_fr.current == $slug)][0].coverImage\n': OG_POST_IMAGE_QUERY_RESULT;
-    '\n*[_type == "album" && slug.current == $slug][0].images[0]\n': OG_ALBUM_IMAGE_QUERY_RESULT;
+    '\n*[_type == "post" && _id == $id][0].coverImage\n': OG_POST_IMAGE_QUERY_RESULT;
+    '\n*[_type == "album" && _id == $id][0].images[0]\n': OG_ALBUM_IMAGE_QUERY_RESULT;
   }
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,3 +3,21 @@ import { expect } from "vitest";
 import { toHaveNoViolations } from "jest-axe";
 
 expect.extend(toHaveNoViolations);
+
+if (typeof window !== "undefined") {
+  const values = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, String(value))
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage
+  });
+}

--- a/todo.md
+++ b/todo.md
@@ -2,7 +2,7 @@
 
 This backlog tracks work discovered after the App Router cutover. Preserve public URLs, bilingual behavior, content, Studio authoring, and the existing visual design throughout.
 
-## Active slice: typed content pipeline
+## Completed slice: typed content pipeline
 
 - [x] Replace generic query casting in `src/sanity/data.ts` with generated Sanity query-result types.
 - [x] Split content access into domain modules for site shell, albums, blog, and pages.
@@ -12,11 +12,15 @@ This backlog tracks work discovered after the App Router cutover. Preserve publi
 - [x] Add unit tests for domain mapping and legacy fallbacks.
 - [x] Re-enable strict lint rules for application code where this slice removes `any` and unsafe casts.
 
+## Active slice: public-content correctness
+
+- [x] Make blog cursor pagination deterministic with an opaque `publishDate` plus `_id` cursor.
+- [x] Generate localized canonical alternatives using the actual English and French slugs.
+- [x] Pass post and album identifiers to the OG endpoint so content-specific images are used.
+- [x] Use blur placeholders only when Sanity provides a usable LQIP.
+
 ## Correctness and public behavior
 
-- [ ] Make blog cursor pagination deterministic with an opaque `publishDate` plus `_id` cursor.
-- [ ] Generate localized canonical alternatives using the actual English and French slugs.
-- [ ] Pass post and album identifiers to the OG endpoint so content-specific images are used.
 - [x] Localize Portable Text internal links.
 - [x] Correct Portable Text external-link target and `rel` behavior.
 - [ ] Build a complete Portable Text image collection so rich-content lightboxes navigate between images.


### PR DESCRIPTION
…agination

- Add tests for Open Graph API endpoint to verify image retrieval for posts and albums.
- Update GET handler to accept postId and albumId for fetching images from Sanity.
- Modify Sanity queries to use document IDs instead of slugs for OG image retrieval.
- Enhance blog pagination with an opaque cursor consisting of publishDate and document ID.
- Introduce localized slugs for posts to generate accurate canonical URLs.
- Ensure blur placeholders are used conditionally based on LQIP availability from Sanity.
- Refactor metadata generation to include localized paths and OG images.
- Update components to handle new props for image placeholders and blur data.